### PR TITLE
Use prop-types & create-react-class packages to remove deprecation warnings

### DIFF
--- a/lib/Tab.js
+++ b/lib/Tab.js
@@ -1,19 +1,21 @@
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var specialAssign = require('./specialAssign');
 
 var checkedProps = {
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.node,
-    React.PropTypes.func,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
   ]).isRequired,
-  id: React.PropTypes.string.isRequired,
-  tag: React.PropTypes.string,
-  index: React.PropTypes.number,
-  active: React.PropTypes.bool,
-  letterNavigationText: React.PropTypes.string,
+  id: PropTypes.string.isRequired,
+  tag: PropTypes.string,
+  index: PropTypes.number,
+  active: PropTypes.bool,
+  letterNavigationText: PropTypes.string,
 };
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'AriaTabPanel-Tab',
 
   propTypes: checkedProps,
@@ -23,7 +25,7 @@ module.exports = React.createClass({
   },
 
   contextTypes: {
-    atpManager: React.PropTypes.object.isRequired,
+    atpManager: PropTypes.object.isRequired,
   },
 
   getInitialState: function() {

--- a/lib/TabList.js
+++ b/lib/TabList.js
@@ -1,12 +1,14 @@
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var specialAssign = require('./specialAssign');
 
 var checkedProps = {
-  children: React.PropTypes.node.isRequired,
-  tag: React.PropTypes.string,
+  children: PropTypes.node.isRequired,
+  tag: PropTypes.string,
 };
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'AriaTabPanel-TabList',
 
   propTypes: checkedProps,

--- a/lib/TabPanel.js
+++ b/lib/TabPanel.js
@@ -1,17 +1,19 @@
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var specialAssign = require('./specialAssign');
 
 var checkedProps = {
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.node,
-    React.PropTypes.func,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
   ]).isRequired,
-  tabId: React.PropTypes.string.isRequired,
-  tag: React.PropTypes.string,
-  active: React.PropTypes.bool,
+  tabId: PropTypes.string.isRequired,
+  tag: PropTypes.string,
+  active: PropTypes.bool,
 };
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'AriaTabPanel-TabPanel',
 
   propTypes: checkedProps,
@@ -21,7 +23,7 @@ module.exports = React.createClass({
   },
 
   contextTypes: {
-    atpManager: React.PropTypes.object.isRequired,
+    atpManager: PropTypes.object.isRequired,
   },
 
   getInitialState: function() {

--- a/lib/Wrapper.js
+++ b/lib/Wrapper.js
@@ -1,16 +1,18 @@
 var React = require('react');
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var createManager = require('./createManager');
 var specialAssign = require('./specialAssign');
 
 var checkedProps = {
-  children: React.PropTypes.node.isRequired,
-  activeTabId: React.PropTypes.string,
-  letterNavigation: React.PropTypes.bool,
-  onChange: React.PropTypes.func,
-  tag: React.PropTypes.string,
+  children: PropTypes.node.isRequired,
+  activeTabId: PropTypes.string,
+  letterNavigation: PropTypes.bool,
+  onChange: PropTypes.func,
+  tag: PropTypes.string,
 };
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   displayName: 'AriaTabPanel-Wrapper',
 
   propTypes: checkedProps,
@@ -20,7 +22,7 @@ module.exports = React.createClass({
   },
 
   childContextTypes: {
-    atpManager: React.PropTypes.object.isRequired,
+    atpManager: PropTypes.object.isRequired,
   },
 
   getChildContext: function() {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "widget"
   ],
   "dependencies": {
-    "focus-group": "^0.2.2"
+    "create-react-class": "^15.6.2",
+    "focus-group": "^0.2.2",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0",


### PR DESCRIPTION
refactor propTypes checking and use create-react-class plugin instead of React.createClass to remove deprecation warnings